### PR TITLE
Workflow fix for deployments

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           entryPoint: ./shabadkosh
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GURMUKHI_DEV }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           channelId: live
           projectId: '${{ secrets.REACT_APP_PROJECT_ID }}'
 
@@ -54,7 +54,7 @@ jobs:
         with:
           entryPoint: ./shabadkosh
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GURMUKHI_DEV }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           channelId: live
           projectId: '${{ secrets.REACT_APP_PROJECT_ID }}'
 
@@ -77,6 +77,6 @@ jobs:
         with:
           entryPoint: ./shabadkosh
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GURMUKHI_DEV }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           channelId: live
           projectId: '${{ secrets.REACT_APP_PROJECT_ID }}'

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -28,5 +28,5 @@ jobs:
         with:
           entryPoint: ./shabadkosh
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GURMUKHI_DEV }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
           projectId: '${{ secrets.REACT_APP_PROJECT_ID }}'


### PR DESCRIPTION

Earlier deployments were crashing as all of them were using the service account key for the dev environment.
This PR fixes it by adding service account json for each env to GitHub secrets.